### PR TITLE
Implement ACME BIAQuiz plugin

### DIFF
--- a/acme-biaquiz/README.md
+++ b/acme-biaquiz/README.md
@@ -1,0 +1,12 @@
+# ACME BIAQuiz
+
+Minimal WordPress plugin providing themed quizzes for BIA training.
+
+Features include:
+- Custom post type for questions with ACF fields `choices` and `answer`.
+- Taxonomy for categories.
+- Shortcode `[acme_bia_quiz category="slug"]` rendering a quiz.
+- REST API endpoint returning 20 random questions per category.
+- Simple JS logic repeating wrong answers until success and displaying final score.
+
+This is a basic implementation meant as starting point for further development.

--- a/acme-biaquiz/acme-biaquiz.php
+++ b/acme-biaquiz/acme-biaquiz.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Plugin Name: ACME BIAQuiz
+ * Description: Provides themed BIA quiz training with import/export features.
+ * Version: 0.1.0
+ * Author: ACME
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Silence is golden!
+}
+
+require_once __DIR__ . '/includes/class-acme-biaquiz.php';
+
+add_action( 'plugins_loaded', [ 'ACME_BIAQuiz', 'instance' ] );

--- a/acme-biaquiz/assets/css/biaquiz.css
+++ b/acme-biaquiz/assets/css/biaquiz.css
@@ -1,0 +1,21 @@
+.acme-biaquiz {
+    max-width: 600px;
+    margin: 0 auto;
+}
+.bia-question ul {
+    list-style: none;
+    padding: 0;
+}
+.bia-question li {
+    margin-bottom: 0.5rem;
+}
+.bia-question button {
+    width: 100%;
+    background: #e2e8f0;
+    padding: 0.5rem;
+    border: none;
+    border-radius: 4px;
+}
+.bia-question button:hover {
+    background: #cbd5e0;
+}

--- a/acme-biaquiz/assets/js/biaquiz.js
+++ b/acme-biaquiz/assets/js/biaquiz.js
@@ -1,0 +1,57 @@
+(function($){
+    function shuffle(array){
+        for(var i=array.length-1;i>0;i--){
+            var j=Math.floor(Math.random()*(i+1));
+            var t=array[i];array[i]=array[j];array[j]=t;
+        }
+    }
+    function Quiz($el){
+        this.$el=$el;
+        this.category=$el.data('category');
+        this.questions=[];
+        this.queue=[];
+        this.score=0;
+        this.current=null;
+        this.init();
+    }
+    Quiz.prototype.init=function(){
+        var self=this;
+        $.getJSON(ACME_BIAQuiz.api,{category:self.category}).done(function(data){
+            self.questions=data;
+            shuffle(self.questions);
+            self.queue=self.questions.slice();
+            self.next();
+        });
+    };
+    Quiz.prototype.next=function(){
+        var self=this;
+        if(!self.queue.length){
+            self.$el.html('<p>Score: '+self.score+'/'+self.questions.length+'</p><button class="acme-biaquiz-restart">Relancer le quiz</button>');
+            return;
+        }
+        self.current=self.queue.shift();
+        var html='<div class="bia-question"><p>'+self.current.title+'</p><ul>';
+        $.each(self.current.choices,function(i,choice){
+            html+='<li><button class="bia-choice" data-index="'+i+'">'+choice+'</button></li>';
+        });
+        html+='</ul></div>';
+        self.$el.html(html);
+    };
+    Quiz.prototype.answer=function(index){
+        if(index==this.current.answer){
+            this.score++;
+        }else{
+            this.queue.push(this.current);
+        }
+        this.next();
+    };
+    $(document).on('click','.bia-choice',function(e){
+        e.preventDefault();
+        var $btn=$(this);var index=$btn.data('index');
+        var $quiz=$btn.closest('.acme-biaquiz').data('quiz');
+        if($quiz){$quiz.answer(index);} });
+    $(document).on('click','.acme-biaquiz-restart',function(){location.reload();});
+    $(function(){
+        $('.acme-biaquiz').each(function(){var q=new Quiz($(this));$(this).data('quiz',q);});
+    });
+})(jQuery);

--- a/acme-biaquiz/includes/class-acme-biaquiz-admin.php
+++ b/acme-biaquiz/includes/class-acme-biaquiz-admin.php
@@ -1,0 +1,73 @@
+<?php
+class ACME_BIAQuiz_Admin {
+    public function __construct() {
+        add_action( 'admin_menu', [ $this, 'menu' ] );
+    }
+
+    public function menu() {
+        add_submenu_page( 'edit.php?post_type='.ACME_BIAQuiz::CPT_QUESTION, __( 'Import/Export', 'acme-biaquiz' ), __( 'Import/Export', 'acme-biaquiz' ), 'manage_options', 'acme-biaquiz-import', [ $this, 'page' ] );
+    }
+
+    public function page() {
+        if ( ! empty( $_POST['acme_biaquiz_import'] ) && current_user_can( 'manage_options' ) ) {
+            $this->handle_import();
+        }
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Import/Export BIA Questions', 'acme-biaquiz' ); ?></h1>
+            <form method="post" enctype="multipart/form-data">
+                <input type="file" name="import_file" />
+                <input type="submit" class="button button-primary" name="acme_biaquiz_import" value="<?php esc_attr_e( 'Import', 'acme-biaquiz' ); ?>" />
+            </form>
+            <p><a class="button" href="<?php echo esc_url( add_query_arg( 'acme_biaquiz_export', '1' ) ); ?>"><?php esc_html_e( 'Export JSON', 'acme-biaquiz' ); ?></a></p>
+        </div>
+        <?php
+        if ( ! empty( $_GET['acme_biaquiz_export'] ) && current_user_can( 'manage_options' ) ) {
+            $this->handle_export();
+            exit;
+        }
+    }
+
+    private function handle_import() {
+        if ( empty( $_FILES['import_file']['tmp_name'] ) ) {
+            return;
+        }
+        $content = file_get_contents( $_FILES['import_file']['tmp_name'] );
+        $data = json_decode( $content, true );
+        if ( ! is_array( $data ) ) {
+            return;
+        }
+        foreach ( $data as $item ) {
+            $post_id = wp_insert_post( [
+                'post_type' => ACME_BIAQuiz::CPT_QUESTION,
+                'post_title' => sanitize_text_field( $item['title'] ),
+                'post_status' => 'publish',
+            ] );
+            if ( $post_id && ! is_wp_error( $post_id ) ) {
+                wp_set_object_terms( $post_id, $item['category'], ACME_BIAQuiz::TAX_CATEGORY );
+                update_field( 'choices', $item['choices'], $post_id );
+                update_field( 'answer', $item['answer'], $post_id );
+            }
+        }
+        echo '<div class="notice notice-success"><p>' . esc_html__( 'Import complete.', 'acme-biaquiz' ) . '</p></div>';
+    }
+
+    private function handle_export() {
+        $args = [ 'post_type' => ACME_BIAQuiz::CPT_QUESTION, 'posts_per_page' => -1 ];
+        $query = new WP_Query( $args );
+        $data = [];
+        foreach ( $query->posts as $post ) {
+            $terms = wp_get_object_terms( $post->ID, ACME_BIAQuiz::TAX_CATEGORY );
+            $data[] = [
+                'title' => $post->post_title,
+                'choices' => get_field( 'choices', $post->ID ),
+                'answer' => get_field( 'answer', $post->ID ),
+                'category' => ! empty( $terms ) ? $terms[0]->slug : '',
+            ];
+        }
+        wp_reset_postdata();
+        header( 'Content-Type: application/json' );
+        header( 'Content-Disposition: attachment; filename="biaquiz-export.json"' );
+        echo wp_json_encode( $data );
+    }
+}

--- a/acme-biaquiz/includes/class-acme-biaquiz.php
+++ b/acme-biaquiz/includes/class-acme-biaquiz.php
@@ -1,0 +1,102 @@
+<?php
+class ACME_BIAQuiz {
+    const CPT_QUESTION = 'acme_bia_question';
+    const TAX_CATEGORY = 'acme_bia_category';
+
+    private static $instance = null;
+
+    public static function instance() {
+        if ( self::$instance === null ) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    private function __construct() {
+        add_action( 'init', [ $this, 'register_post_types' ] );
+        add_action( 'init', [ $this, 'register_taxonomies' ] );
+        add_shortcode( 'acme_bia_quiz', [ $this, 'quiz_shortcode' ] );
+        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+        add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
+        if ( is_admin() ) {
+            require_once __DIR__ . '/class-acme-biaquiz-admin.php';
+            new ACME_BIAQuiz_Admin();
+        }
+    }
+
+    public function register_post_types() {
+        register_post_type( self::CPT_QUESTION, [
+            'label' => __( 'BIA Questions', 'acme-biaquiz' ),
+            'public' => false,
+            'show_ui' => true,
+            'supports' => [ 'title' ],
+        ] );
+    }
+
+    public function register_taxonomies() {
+        register_taxonomy( self::TAX_CATEGORY, self::CPT_QUESTION, [
+            'label' => __( 'BIA Categories', 'acme-biaquiz' ),
+            'public' => true,
+            'show_ui' => true,
+            'hierarchical' => false,
+        ] );
+    }
+
+    public function enqueue_assets() {
+        wp_enqueue_style( 'acme-biaquiz', plugins_url( 'assets/css/biaquiz.css', dirname( __FILE__ ) ) );
+        wp_enqueue_script( 'acme-biaquiz', plugins_url( 'assets/js/biaquiz.js', dirname( __FILE__ ) ), [ 'jquery' ], '1.0', true );
+        wp_localize_script( 'acme-biaquiz', 'ACME_BIAQuiz', [
+            'api' => esc_url_raw( rest_url( 'acme-biaquiz/v1/questions' ) ),
+        ] );
+    }
+
+    public function quiz_shortcode( $atts ) {
+        $atts = shortcode_atts( [ 'category' => '' ], $atts, 'acme_bia_quiz' );
+        ob_start();
+        ?>
+        <div class="acme-biaquiz" data-category="<?php echo esc_attr( $atts['category'] ); ?>"></div>
+        <?php
+        return ob_get_clean();
+    }
+
+    public function register_rest_routes() {
+        register_rest_route( 'acme-biaquiz/v1', '/questions', [
+            'methods' => 'GET',
+            'callback' => [ $this, 'rest_get_questions' ],
+            'args' => [
+                'category' => [ 'sanitize_callback' => 'sanitize_text_field' ],
+            ],
+            'permission_callback' => '__return_true',
+        ] );
+    }
+
+    public function rest_get_questions( $request ) {
+        $category = $request->get_param( 'category' );
+        $args = [
+            'post_type' => self::CPT_QUESTION,
+            'posts_per_page' => 20,
+            'orderby' => 'rand',
+        ];
+        if ( $category ) {
+            $args['tax_query'] = [
+                [
+                    'taxonomy' => self::TAX_CATEGORY,
+                    'field'    => 'slug',
+                    'terms'    => $category,
+                ],
+            ];
+        }
+        $query = new WP_Query( $args );
+        $questions = [];
+        foreach ( $query->posts as $post ) {
+            $questions[] = [
+                'id' => $post->ID,
+                'title' => $post->post_title,
+                'choices' => get_field( 'choices', $post->ID ),
+                'answer' => get_field( 'answer', $post->ID ),
+            ];
+        }
+        wp_reset_postdata();
+        return $questions;
+    }
+}


### PR DESCRIPTION
## Summary
- add ACME BIAQuiz WordPress plugin skeleton
- support CPT for quiz questions and categories
- provide REST API endpoint and frontend logic
- allow admin import/export of questions

## Testing
- `php -l` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea9a2e044832bb751209a36591c1a