### PR TITLE
Add default categories for BIAQuiz plugin

### DIFF
--- a/acme-biaquiz/README.md
+++ b/acme-biaquiz/README.md
@@ -5,6 +5,13 @@ Minimal WordPress plugin providing themed quizzes for BIA training.
 Features include:
 - Custom post type for questions with ACF fields `choices` and `answer`.
 - Taxonomy for categories.
+- Six default categories are created on activation:
+  1. Aérodynamique et mécanique du vol
+  2. Connaissance des aéronefs
+  3. Météorologie
+  4. Navigation, règlementation et sécurité des vols
+  5. Histoire de l'aéronautique et de l'espace
+  6. Anglais aéronautique
 - Shortcode `[acme_bia_quiz category="slug"]` rendering a quiz.
 - REST API endpoint returning 20 random questions per category.
 - Simple JS logic repeating wrong answers until success and displaying final score.

--- a/acme-biaquiz/acme-biaquiz.php
+++ b/acme-biaquiz/acme-biaquiz.php
@@ -12,4 +12,30 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once __DIR__ . '/includes/class-acme-biaquiz.php';
 
+/**
+ * Create default quiz categories on plugin activation.
+ */
+function acme_biaquiz_activate() {
+    $plugin = ACME_BIAQuiz::instance();
+    $plugin->register_post_types();
+    $plugin->register_taxonomies();
+
+    $categories = [
+        'Aérodynamique et mécanique du vol',
+        'Connaissance des aéronefs',
+        'Météorologie',
+        'Navigation, règlementation et sécurité des vols',
+        "Histoire de l'aéronautique et de l'espace",
+        'Anglais aéronautique',
+    ];
+
+    foreach ( $categories as $category ) {
+        if ( ! term_exists( $category, ACME_BIAQuiz::TAX_CATEGORY ) ) {
+            wp_insert_term( $category, ACME_BIAQuiz::TAX_CATEGORY );
+        }
+    }
+}
+
+register_activation_hook( __FILE__, 'acme_biaquiz_activate' );
+
 add_action( 'plugins_loaded', [ 'ACME_BIAQuiz', 'instance' ] );


### PR DESCRIPTION
## Summary
- create default taxonomy terms during plugin activation
- document the new categories in the ACME BIAQuiz readme

## Testing
- `php -l acme-biaquiz/acme-biaquiz.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685eb2ad72cc832bbf1c63319412c8db