### PR TITLE
Add explanation support with CSV import/export

### DIFF
--- a/acme-biaquiz/assets/js/biaquiz.js
+++ b/acme-biaquiz/assets/js/biaquiz.js
@@ -12,6 +12,7 @@
         this.queue=[];
         this.score=0;
         this.current=null;
+        this.awaitingNext=false;
         this.init();
     }
     Quiz.prototype.init=function(){
@@ -29,6 +30,7 @@
             self.$el.html('<p>Score: '+self.score+'/'+self.questions.length+'</p><button class="acme-biaquiz-restart">Relancer le quiz</button>');
             return;
         }
+        self.awaitingNext=false;
         self.current=self.queue.shift();
         var html='<div class="bia-question"><p>'+self.current.title+'</p><ul>';
         $.each(self.current.choices,function(i,choice){
@@ -38,18 +40,30 @@
         self.$el.html(html);
     };
     Quiz.prototype.answer=function(index){
+        if(this.awaitingNext){return;}
         if(index==this.current.answer){
             this.score++;
         }else{
             this.queue.push(this.current);
         }
-        this.next();
+        this.awaitingNext=true;
+        var html='<div class="bia-explanation">';
+        if(this.current.explanation){
+            html+='<p>'+this.current.explanation+'</p>';
+        }
+        html+='<button class="bia-next">Suivant</button></div>';
+        this.$el.find('.bia-question').append(html);
     };
     $(document).on('click','.bia-choice',function(e){
         e.preventDefault();
         var $btn=$(this);var index=$btn.data('index');
         var $quiz=$btn.closest('.acme-biaquiz').data('quiz');
         if($quiz){$quiz.answer(index);} });
+    $(document).on('click','.bia-next',function(e){
+        e.preventDefault();
+        var $quiz=$(this).closest('.acme-biaquiz').data('quiz');
+        if($quiz){$quiz.next();}
+    });
     $(document).on('click','.acme-biaquiz-restart',function(){location.reload();});
     $(function(){
         $('.acme-biaquiz').each(function(){var q=new Quiz($(this));$(this).data('quiz',q);});

--- a/acme-biaquiz/includes/class-acme-biaquiz-admin.php
+++ b/acme-biaquiz/includes/class-acme-biaquiz-admin.php
@@ -19,7 +19,7 @@ class ACME_BIAQuiz_Admin {
                 <input type="file" name="import_file" />
                 <input type="submit" class="button button-primary" name="acme_biaquiz_import" value="<?php esc_attr_e( 'Import', 'acme-biaquiz' ); ?>" />
             </form>
-            <p><a class="button" href="<?php echo esc_url( add_query_arg( 'acme_biaquiz_export', '1' ) ); ?>"><?php esc_html_e( 'Export JSON', 'acme-biaquiz' ); ?></a></p>
+            <p><a class="button" href="<?php echo esc_url( add_query_arg( 'acme_biaquiz_export', '1' ) ); ?>"><?php esc_html_e( 'Export CSV', 'acme-biaquiz' ); ?></a></p>
         </div>
         <?php
         if ( ! empty( $_GET['acme_biaquiz_export'] ) && current_user_can( 'manage_options' ) ) {
@@ -32,42 +32,102 @@ class ACME_BIAQuiz_Admin {
         if ( empty( $_FILES['import_file']['tmp_name'] ) ) {
             return;
         }
-        $content = file_get_contents( $_FILES['import_file']['tmp_name'] );
-        $data = json_decode( $content, true );
-        if ( ! is_array( $data ) ) {
-            return;
-        }
-        foreach ( $data as $item ) {
-            $post_id = wp_insert_post( [
-                'post_type' => ACME_BIAQuiz::CPT_QUESTION,
-                'post_title' => sanitize_text_field( $item['title'] ),
-                'post_status' => 'publish',
-            ] );
-            if ( $post_id && ! is_wp_error( $post_id ) ) {
-                wp_set_object_terms( $post_id, $item['category'], ACME_BIAQuiz::TAX_CATEGORY );
-                update_field( 'choices', $item['choices'], $post_id );
-                update_field( 'answer', $item['answer'], $post_id );
+
+        $file = $_FILES['import_file']['tmp_name'];
+        $ext  = strtolower( pathinfo( $_FILES['import_file']['name'], PATHINFO_EXTENSION ) );
+
+        $rows = [];
+
+        if ( 'csv' === $ext ) {
+            if ( ( $handle = fopen( $file, 'r' ) ) ) {
+                while ( ( $data = fgetcsv( $handle ) ) !== false ) {
+                    $rows[] = $data;
+                }
+                fclose( $handle );
+            }
+        } else {
+            $content = file_get_contents( $file );
+            $data    = json_decode( $content, true );
+            if ( is_array( $data ) ) {
+                $rows = $data;
             }
         }
+
+        if ( empty( $rows ) ) {
+            return;
+        }
+
+        // Skip header row if present.
+        if ( isset( $rows[0][0] ) && strtolower( $rows[0][0] ) === 'category' ) {
+            array_shift( $rows );
+        }
+
+        foreach ( $rows as $item ) {
+            if ( is_array( $item ) ) {
+                // CSV format.
+                $category  = isset( $item[0] ) ? sanitize_text_field( $item[0] ) : '';
+                $question  = isset( $item[1] ) ? sanitize_text_field( $item[1] ) : '';
+                $choices   = array_slice( $item, 2, 4 );
+                $answer    = isset( $item[6] ) ? intval( $item[6] ) : 0;
+                $answer    = $answer > 0 ? $answer - 1 : $answer; // convert to 0 index
+                $explain   = isset( $item[7] ) ? sanitize_textarea_field( $item[7] ) : '';
+            } else {
+                // JSON legacy format.
+                $category = $item['category'];
+                $question = $item['title'];
+                $choices  = $item['choices'];
+                $answer   = intval( $item['answer'] );
+                $explain  = isset( $item['explanation'] ) ? $item['explanation'] : '';
+            }
+
+            $post_id = wp_insert_post( [
+                'post_type'   => ACME_BIAQuiz::CPT_QUESTION,
+                'post_title'  => $question,
+                'post_status' => 'publish',
+            ] );
+
+            if ( $post_id && ! is_wp_error( $post_id ) ) {
+                wp_set_object_terms( $post_id, $category, ACME_BIAQuiz::TAX_CATEGORY );
+                update_field( 'choices', $choices, $post_id );
+                update_field( 'answer', $answer, $post_id );
+                update_field( 'explanation', $explain, $post_id );
+            }
+        }
+
         echo '<div class="notice notice-success"><p>' . esc_html__( 'Import complete.', 'acme-biaquiz' ) . '</p></div>';
     }
 
     private function handle_export() {
-        $args = [ 'post_type' => ACME_BIAQuiz::CPT_QUESTION, 'posts_per_page' => -1 ];
+        $args  = [ 'post_type' => ACME_BIAQuiz::CPT_QUESTION, 'posts_per_page' => -1 ];
         $query = new WP_Query( $args );
-        $data = [];
+
+        header( 'Content-Type: text/csv' );
+        header( 'Content-Disposition: attachment; filename="biaquiz-export.csv"' );
+
+        $output = fopen( 'php://output', 'w' );
+        fputcsv( $output, [ 'category', 'question', 'option1', 'option2', 'option3', 'option4', 'correct_answer', 'explanation' ] );
+
         foreach ( $query->posts as $post ) {
-            $terms = wp_get_object_terms( $post->ID, ACME_BIAQuiz::TAX_CATEGORY );
-            $data[] = [
-                'title' => $post->post_title,
-                'choices' => get_field( 'choices', $post->ID ),
-                'answer' => get_field( 'answer', $post->ID ),
-                'category' => ! empty( $terms ) ? $terms[0]->slug : '',
+            $terms     = wp_get_object_terms( $post->ID, ACME_BIAQuiz::TAX_CATEGORY );
+            $choices   = (array) get_field( 'choices', $post->ID );
+            $choices   = array_pad( $choices, 4, '' );
+            $answer    = intval( get_field( 'answer', $post->ID ) );
+            $explain   = get_field( 'explanation', $post->ID );
+
+            $row = [
+                ! empty( $terms ) ? $terms[0]->slug : '',
+                $post->post_title,
+                $choices[0],
+                $choices[1],
+                $choices[2],
+                $choices[3],
+                $answer + 1,
+                $explain,
             ];
+
+            fputcsv( $output, $row );
         }
+        fclose( $output );
         wp_reset_postdata();
-        header( 'Content-Type: application/json' );
-        header( 'Content-Disposition: attachment; filename="biaquiz-export.json"' );
-        echo wp_json_encode( $data );
     }
 }

--- a/acme-biaquiz/includes/class-acme-biaquiz.php
+++ b/acme-biaquiz/includes/class-acme-biaquiz.php
@@ -90,10 +90,11 @@ class ACME_BIAQuiz {
         $questions = [];
         foreach ( $query->posts as $post ) {
             $questions[] = [
-                'id' => $post->ID,
-                'title' => $post->post_title,
-                'choices' => get_field( 'choices', $post->ID ),
-                'answer' => get_field( 'answer', $post->ID ),
+                'id'          => $post->ID,
+                'title'       => $post->post_title,
+                'choices'     => get_field( 'choices', $post->ID ),
+                'answer'      => get_field( 'answer', $post->ID ),
+                'explanation' => get_field( 'explanation', $post->ID ),
             ];
         }
         wp_reset_postdata();


### PR DESCRIPTION
## Summary
- support CSV import with explanation column in admin class
- export quiz data to CSV and include explanation
- add explanation field to REST output
- show explanations and next button after answering questions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685eb71f33b4832bbecea5bb20d9c4aa