### PR TITLE
Define plugin constant for asset paths

### DIFF
--- a/acme-biaquiz.php
+++ b/acme-biaquiz.php
@@ -10,6 +10,11 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit; // Silence is golden!
 }
 
+// Reference to the main plugin file for asset loading and other helpers.
+if ( ! defined( 'ACME_BIAQUIZ_FILE' ) ) {
+    define( 'ACME_BIAQUIZ_FILE', __FILE__ );
+}
+
 require_once __DIR__ . '/includes/class-acme-biaquiz.php';
 
 /**

--- a/includes/class-acme-biaquiz.php
+++ b/includes/class-acme-biaquiz.php
@@ -43,8 +43,8 @@ class ACME_BIAQuiz {
     }
 
     public function enqueue_assets() {
-        wp_enqueue_style( 'acme-biaquiz', plugins_url( 'assets/css/biaquiz.css', dirname( __FILE__ ) ) );
-        wp_enqueue_script( 'acme-biaquiz', plugins_url( 'assets/js/biaquiz.js', dirname( __FILE__ ) ), [ 'jquery' ], '1.0', true );
+        wp_enqueue_style( 'acme-biaquiz', plugins_url( 'assets/css/biaquiz.css', ACME_BIAQUIZ_FILE ) );
+        wp_enqueue_script( 'acme-biaquiz', plugins_url( 'assets/js/biaquiz.js', ACME_BIAQUIZ_FILE ), [ 'jquery' ], '1.0', true );
         wp_localize_script( 'acme-biaquiz', 'ACME_BIAQuiz', [
             'api' => esc_url_raw( rest_url( 'acme-biaquiz/v1/questions' ) ),
         ] );


### PR DESCRIPTION
## Summary
- add `ACME_BIAQUIZ_FILE` constant in the main plugin file
- use this constant for asset path resolution

## Testing
- `php -l acme-biaquiz.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec0420b98832bb3a9032730d0f991