### PR TITLE
Add nonce checks for import/export

### DIFF
--- a/includes/class-acme-biaquiz-admin.php
+++ b/includes/class-acme-biaquiz-admin.php
@@ -16,10 +16,12 @@ class ACME_BIAQuiz_Admin {
         <div class="wrap">
             <h1><?php esc_html_e( 'Import/Export BIA Questions', 'acme-biaquiz' ); ?></h1>
             <form method="post" enctype="multipart/form-data">
+                <?php wp_nonce_field( 'acme_biaquiz_import', 'acme_biaquiz_nonce' ); ?>
                 <input type="file" name="import_file" />
                 <input type="submit" class="button button-primary" name="acme_biaquiz_import" value="<?php esc_attr_e( 'Import', 'acme-biaquiz' ); ?>" />
             </form>
-            <p><a class="button" href="<?php echo esc_url( add_query_arg( 'acme_biaquiz_export', '1' ) ); ?>"><?php esc_html_e( 'Export CSV', 'acme-biaquiz' ); ?></a></p>
+            <?php $export_url = wp_nonce_url( add_query_arg( 'acme_biaquiz_export', '1' ), 'acme_biaquiz_import', 'acme_biaquiz_nonce' ); ?>
+            <p><a class="button" href="<?php echo esc_url( $export_url ); ?>"><?php esc_html_e( 'Export CSV', 'acme-biaquiz' ); ?></a></p>
         </div>
         <?php
         if ( ! empty( $_GET['acme_biaquiz_export'] ) && current_user_can( 'manage_options' ) ) {
@@ -29,6 +31,10 @@ class ACME_BIAQuiz_Admin {
     }
 
     private function handle_import() {
+        if ( empty( $_POST['acme_biaquiz_nonce'] ) || ! wp_verify_nonce( $_POST['acme_biaquiz_nonce'], 'acme_biaquiz_import' ) ) {
+            return;
+        }
+
         if ( empty( $_FILES['import_file']['tmp_name'] ) ) {
             return;
         }
@@ -98,6 +104,10 @@ class ACME_BIAQuiz_Admin {
     }
 
     private function handle_export() {
+        if ( empty( $_GET['acme_biaquiz_nonce'] ) || ! wp_verify_nonce( $_GET['acme_biaquiz_nonce'], 'acme_biaquiz_import' ) ) {
+            return;
+        }
+
         $args  = [ 'post_type' => ACME_BIAQuiz::CPT_QUESTION, 'posts_per_page' => -1 ];
         $query = new WP_Query( $args );
 


### PR DESCRIPTION
## Summary
- secure import/export page with a nonce field
- verify nonce in both import and export handlers
- pass nonce when exporting

## Testing
- `php -l includes/class-acme-biaquiz-admin.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec0438444832bbc29e63bc4edc662