### PR TITLE
Add ACF availability check

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Minimal WordPress plugin providing themed quizzes for BIA training.
 
 Features include:
 - Custom post type for questions with ACF fields `choices` and `answer`.
+- Requires the Advanced Custom Fields plugin. If ACF is not active, REST and import/export features are disabled.
 - Taxonomy for categories.
 - Six default categories are created on activation:
   1. Aérodynamique et mécanique du vol


### PR DESCRIPTION
## Summary
- check for ACF on initialization
- show admin warning when ACF is missing
- disable REST and admin features if ACF isn't available
- document the dependency in the README

## Testing
- `php -l includes/class-acme-biaquiz.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ec0438a8c832b826fad987f229396