### PR TITLE
Add textdomain loader

### DIFF
--- a/acme-biaquiz.php
+++ b/acme-biaquiz.php
@@ -10,6 +10,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit; // Silence is golden!
 }
 
+if ( ! defined( 'ACME_BIAQUIZ_FILE' ) ) {
+    define( 'ACME_BIAQUIZ_FILE', __FILE__ );
+}
+
 require_once __DIR__ . '/includes/class-acme-biaquiz.php';
 
 /**

--- a/includes/class-acme-biaquiz.php
+++ b/includes/class-acme-biaquiz.php
@@ -15,6 +15,7 @@ class ACME_BIAQuiz {
     private function __construct() {
         add_action( 'init', [ $this, 'register_post_types' ] );
         add_action( 'init', [ $this, 'register_taxonomies' ] );
+        add_action( 'init', [ $this, 'load_textdomain' ] );
         add_shortcode( 'acme_bia_quiz', [ $this, 'quiz_shortcode' ] );
         add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ] );
         add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
@@ -40,6 +41,10 @@ class ACME_BIAQuiz {
             'show_ui' => true,
             'hierarchical' => false,
         ] );
+    }
+
+    public function load_textdomain() {
+        load_plugin_textdomain( 'acme-biaquiz', false, dirname( plugin_basename( ACME_BIAQUIZ_FILE ) ) . '/languages' );
     }
 
     public function enqueue_assets() {


### PR DESCRIPTION
## Summary
- define `ACME_BIAQUIZ_FILE`
- add `load_textdomain()` method and hook it

## Testing
- `php -l acme-biaquiz.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec045bdd4832ba79fc6b640f7eb40