### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,33 @@ Features include:
 - Simple JS logic repeating wrong answers until success and displaying final score.
 
 This is a basic implementation meant as starting point for further development.
+
+
+## Installation
+
+1. Upload the plugin folder to `wp-content/plugins` or install it through the WordPress plugin uploader.
+2. Install and activate the **Advanced Custom Fields** plugin. The quiz questions rely on the `choices`, `answer` and `explanation` fields created with ACF.
+3. Activate **ACME BIAQuiz** from the Plugins menu. Default categories will be created automatically.
+
+## Usage
+
+Insert the shortcode `[acme_bia_quiz]` into any post or page. Use the optional `category` attribute to display questions from a specific category slug:
+
+```
+[acme_bia_quiz category="meteo"]
+```
+
+## Import/Export
+
+An Import/Export submenu is available under **BIA Questions**. Questions can be imported or exported as CSV files. The columns are:
+
+```
+category,question,option1,option2,option3,option4,correct_answer,explanation
+```
+
+`correct_answer` is the 1‑based index of the correct choice.
+
+## REST API
+
+Questions are accessible through `wp-json/acme-biaquiz/v1/questions`. Passing a `category` parameter filters by category. The endpoint returns up to 20 random questions.
+


### PR DESCRIPTION
## Summary
- document plugin installation
- mention ACF dependency
- explain `[acme_bia_quiz]` shortcode usage
- outline import/export CSV format
- describe available REST API endpoint

## Testing
- `php -l acme-biaquiz.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec047789c832ba01eecc1d6ad9d4a